### PR TITLE
Rollback modal-body template for simple confirmation dialog

### DIFF
--- a/projects/extra-clarity/dialog/src/containers/confirmation-dialog/confirmation-dialog.component.html
+++ b/projects/extra-clarity/dialog/src/containers/confirmation-dialog/confirmation-dialog.component.html
@@ -6,11 +6,9 @@
   <div dialog-title>{{ config.title }}</div>
 
   <div dialog-content>
-    <clr-alert *ngIf="config.message" [clrAlertType]="config.type ?? 'info'" [clrAlertClosable]="false">
-      <clr-alert-item>
-        <span class="alert-text">{{ config.message }}</span>
-      </clr-alert-item>
-    </clr-alert>
+    <div *ngIf="!config.template && !config.component">
+      {{ config.message }}
+    </div>
 
     <ng-container
       *ngIf="config.template"

--- a/projects/extra-clarity/dialog/src/dialog.module.ts
+++ b/projects/extra-clarity/dialog/src/dialog.module.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { ClrAlertModule, ClrLoadingButtonModule, ClrLoadingModule, ClrModalModule } from '@clr/angular';
+import { ClrLoadingButtonModule, ClrLoadingModule, ClrModalModule } from '@clr/angular';
 
 import { ConfirmationDialogComponent, DialogContainer } from './containers';
 import { DialogCloseDirective, DialogContentDirective, DialogFooterDirective, DialogTitleDirective } from './directives';
@@ -21,7 +21,6 @@ const DIRECTIVES = [
   ],
   imports: [
     CommonModule,
-    ClrAlertModule,
     ClrModalModule,
     ClrLoadingModule,
     ClrLoadingButtonModule,


### PR DESCRIPTION
I suggest rolling back to a simple container for the {{ confirm.message }} dialog content.
I propose to use `<div>` (not `<p>`) as a wrapper, because `<div>` does not have any specific styles in the original Clarity library. On the contrary, `<p>` has a significant margin-top which may be inconvenient for some cases.